### PR TITLE
Replace Docker container with ruby/setup-ruby action

### DIFF
--- a/.github/workflows/exec.yml
+++ b/.github/workflows/exec.yml
@@ -16,18 +16,15 @@ on:
 
 jobs:
   exec:
-    runs-on: ubuntu-20.04
-    timeout-minutes: 300
-    container: ruby:2.7.6
-
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Setup Ruby environment
-        run: |
-          gem install bundler:2.2.19
-          bundle install
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "2.7.6"
+      - name: Install dependencies
+        run: bundle install
 
       - name: Execute report.rb
         env:


### PR DESCRIPTION
## Changes Proposed in This Pull Request:

This PR optimizes our CI workflow by replacing the Docker container-based Ruby setup with the [ruby/setup-ruby](https://github.com/ruby/setup-ruby) GitHub action. This change aims to improve performance and reduce the execution time of our CI pipeline.

### Key Modifications:
- Removed the `container: ruby:2.7.6` specification
- Replaced manual Ruby environment setup with the `ruby/setup-ruby@v1` action
- Removed explicit bundler version installation
- Maintained Ruby version at 2.7.6

### Benefits:
1. Faster execution due to built-in caching mechanisms
2. Reduced overhead by running directly on the host machine
3. Simplified configuration and easier maintenance
4. Optimization for the GitHub Actions environment

### Notes:
- The `timeout-minutes: 300` setting has been removed. If needed, we can add it back or adjust it as necessary
- Bundle installation is now a separate step for clarity

### Examples:

- Before (use docker container): [exec@529379c](https://github.com/obikosato/github-actions-with-ruby/actions/runs/11165086432) ...31s
- After (use ruby/setup-ruby `#1`): [exec@fac6d93 attempt/1](https://github.com/obikosato/github-actions-with-ruby/actions/runs/11165089586/attempts/1)...22s
- After (use ruby/setup-ruby `#2`): [exec@fac6d93 attempt/2](https://github.com/obikosato/github-actions-with-ruby/actions/runs/11165089586/attempts/2)...18s
